### PR TITLE
Add agent lifecycle workflow

### DIFF
--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -23,7 +23,12 @@ import {
   Add as AddIcon,
 } from '@mui/icons-material';
 import { RootState } from '../store';
-import { fetchAgents } from '../store/slices/agentSlice';
+import {
+  fetchAgents,
+  startAgent,
+  stopAgent,
+  restartAgent,
+} from '../store/slices/agentSlice';
 
 const Agents: React.FC = () => {
   const dispatch = useDispatch();
@@ -36,18 +41,15 @@ const Agents: React.FC = () => {
   }, [dispatch]);
 
   const handleStartAgent = (agentId: string) => {
-    // TODO: Implement agent start
-    console.log('Start agent:', agentId);
+    dispatch(startAgent(agentId));
   };
 
   const handleStopAgent = (agentId: string) => {
-    // TODO: Implement agent stop
-    console.log('Stop agent:', agentId);
+    dispatch(stopAgent(agentId));
   };
 
   const handleRestartAgent = (agentId: string) => {
-    // TODO: Implement agent restart
-    console.log('Restart agent:', agentId);
+    dispatch(restartAgent(agentId));
   };
 
   const handleCreateAgent = () => {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,9 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import systemReducer from './slices/systemSlice';
+import agentReducer from './slices/agentSlice';
+import messageReducer from './slices/messageSlice';
 
 export const store = configureStore({
   reducer: {
     system: systemReducer,
+    agents: agentReducer,
+    messages: messageReducer,
   },
 });
 

--- a/frontend/src/store/slices/agentSlice.ts
+++ b/frontend/src/store/slices/agentSlice.ts
@@ -39,6 +39,30 @@ export const fetchAgent = createAsyncThunk(
   }
 );
 
+export const startAgent = createAsyncThunk(
+  'agents/startAgent',
+  async (agentId: string) => {
+    const response = await axios.post(`/api/agents/${agentId}/start`);
+    return response.data;
+  }
+);
+
+export const stopAgent = createAsyncThunk(
+  'agents/stopAgent',
+  async (agentId: string) => {
+    const response = await axios.post(`/api/agents/${agentId}/stop`);
+    return response.data;
+  }
+);
+
+export const restartAgent = createAsyncThunk(
+  'agents/restartAgent',
+  async (agentId: string) => {
+    const response = await axios.post(`/api/agents/${agentId}/restart`);
+    return response.data;
+  }
+);
+
 const agentSlice = createSlice({
   name: 'agents',
   initialState,
@@ -75,6 +99,33 @@ const agentSlice = createSlice({
       .addCase(fetchAgent.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message || 'Failed to fetch agent';
+      })
+      .addCase(startAgent.fulfilled, (state, action) => {
+        const idx = state.agents.findIndex(a => a.id === action.payload.id);
+        if (idx !== -1) {
+          state.agents[idx] = { ...state.agents[idx], ...action.payload, status: action.payload.state } as Agent;
+        }
+        if (state.selectedAgent && state.selectedAgent.id === action.payload.id) {
+          state.selectedAgent = { ...state.selectedAgent, ...action.payload, status: action.payload.state } as Agent;
+        }
+      })
+      .addCase(stopAgent.fulfilled, (state, action) => {
+        const idx = state.agents.findIndex(a => a.id === action.payload.id);
+        if (idx !== -1) {
+          state.agents[idx] = { ...state.agents[idx], ...action.payload, status: action.payload.state } as Agent;
+        }
+        if (state.selectedAgent && state.selectedAgent.id === action.payload.id) {
+          state.selectedAgent = { ...state.selectedAgent, ...action.payload, status: action.payload.state } as Agent;
+        }
+      })
+      .addCase(restartAgent.fulfilled, (state, action) => {
+        const idx = state.agents.findIndex(a => a.id === action.payload.id);
+        if (idx !== -1) {
+          state.agents[idx] = { ...state.agents[idx], ...action.payload, status: action.payload.state } as Agent;
+        }
+        if (state.selectedAgent && state.selectedAgent.id === action.payload.id) {
+          state.selectedAgent = { ...state.selectedAgent, ...action.payload, status: action.payload.state } as Agent;
+        }
       });
   },
 });


### PR DESCRIPTION
## Summary
- support start/stop/restart endpoints for agents
- expose lifecycle actions in Redux agent slice
- integrate lifecycle buttons on Agents page
- register reducers for agents and messages
- add unit test coverage for lifecycle endpoints

## Testing
- `pytest backend/tests/test_api.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6847c9dc6810832fa8a39f614fa52a0b