### PR TITLE
Remove unused variable in visualization

### DIFF
--- a/visualization.py
+++ b/visualization.py
@@ -39,14 +39,11 @@ class AgentVisualizer:
 
         edge_x = []
         edge_y = []
-        edge_colors = []
         for u, v in self.edges:
             x0, y0 = self.pos[u]
             x1, y1 = self.pos[v]
             edge_x += [x0, x1, None]
             edge_y += [y0, y1, None]
-            color = "red" if (u, v) in highlight else "gray"
-            edge_colors.append(color)
 
         edge_trace = go.Scatter(
             x=edge_x,


### PR DESCRIPTION
## Summary
- clean up unused `edge_colors` variable in `AgentVisualizer.create_animation_frame`

## Testing
- `python test_setup.py` *(fails: No module named 'streamlit', 'requests', etc., but Visualization test passes)*
- `python - <<'PY'
from visualization import AgentVisualizer
viz = AgentVisualizer()
fig = viz.create_animation_frame([('CEO','Worker')])
print('Edges:', fig.data[0].line.color)
print('Highlight overlay count', len(fig.data))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6847c9d8e0d0832f913059627320adaf