### PR TITLE
Fix cleanup return count

### DIFF
--- a/backend/ai_lab/core/database.py
+++ b/backend/ai_lab/core/database.py
@@ -298,7 +298,8 @@ class DatabaseManager:
                 cutoff = datetime.utcnow().timestamp() - (max_age_hours * 3600)
                 
                 # Delete inactive agents (cascade will handle related records)
-                self._conn.execute("""
+                cursor = self._conn.execute(
+                    """
                     DELETE FROM agents
                     WHERE id IN (
                         SELECT a.id
@@ -307,9 +308,11 @@ class DatabaseManager:
                         WHERE s.last_updated < datetime(?, 'unixepoch')
                         OR s.last_updated IS NULL
                     )
-                """, (cutoff,))
-                
-                removed = self._conn.total_changes
+                    """,
+                    (cutoff,),
+                )
+
+                removed = cursor.rowcount
                 self._conn.commit()
                 return removed
                 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from datetime import datetime, timedelta
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ai_lab.core.database import DatabaseManager
+from ai_lab.models.base import AgentStatus, AgentRole, AgentState, AgentMetrics
+
+@pytest.mark.asyncio
+async def test_cleanup_inactive_agents_returns_removed_count(tmp_path):
+    db_path = tmp_path / "test.db"
+    manager = DatabaseManager(str(db_path))
+    await manager.connect()
+
+    old_agent = AgentStatus(
+        id=uuid.uuid4(),
+        role=AgentRole.WORKER,
+        state=AgentState.IDLE,
+        current_task=None,
+        metrics=AgentMetrics(),
+        last_updated=datetime.utcnow() - timedelta(hours=2),
+    )
+
+    active_agent = AgentStatus(
+        id=uuid.uuid4(),
+        role=AgentRole.WORKER,
+        state=AgentState.IDLE,
+        current_task=None,
+        metrics=AgentMetrics(),
+        last_updated=datetime.utcnow(),
+    )
+
+    await manager.update_agent_status(old_agent)
+    await manager.update_agent_status(active_agent)
+
+    removed = await manager.cleanup_inactive_agents(max_age_hours=1)
+    assert removed == 1
+
+    remaining = await manager.get_agent_status(str(active_agent.id))
+    assert remaining is not None
+
+    await manager.disconnect()


### PR DESCRIPTION
## Summary
- update `cleanup_inactive_agents` to report deleted rows correctly
- add regression test for inactive agent cleanup

## Testing
- `pytest backend/tests/test_database.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d2f66260832f963e93ef4742324f